### PR TITLE
hotfix：解决关键字误判的问题

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -39,13 +39,19 @@ func Open(path string) (*os.File, error) {
 }
 
 // FindNotExistKeys 在文件中查找不存在于维度列表中的维度
-func FindNotExistKeys(path string, keys []string) (result []string, err error) {
+func FindNotExistKeys(path string, dataSource string, keys []string) (result []string, err error) {
 	if keys == nil || len(keys) == 0 {
 		// 可以使用斜杠对引号进行转义
 		// return nil, errors.New("param \"dimensions\" is invalid")
 		// 反引号表示原生字符串,不可转义,可包含多行
 		// return nil, errors.New(`param "dimensions" is invalid`)
 		return nil, ParamDimensionsError
+	}
+
+	// 根据数据源加工出对应的表名关键字
+	source := "gongshang"
+	if dataSource != "mini" {
+		source += "_" + dataSource
 	}
 	// 通过grep命令查找文件中是否包含关键字, 如果原始命中中包含空格，则必须分成多个参数传入
 	// 如果有多条命令，则必须每个命令使用一个exec
@@ -54,7 +60,8 @@ func FindNotExistKeys(path string, keys []string) (result []string, err error) {
 	for _, key := range keys {
 		cmd := exec.Command(
 			"bash", "-c",
-			fmt.Sprintf(`grep -q %s_ds %s && echo %d || echo %d`, key, path, GrepContain, GrepNotContain),
+			fmt.Sprintf(`grep -q "dwd_ei_basic_%s_%s_ds/p_date" %s && echo %d || echo %d`,
+				source, strings.ToLower(key), path, GrepContain, GrepNotContain),
 		)
 		outputByte, err := cmd.Output()
 		if err != nil {

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -125,12 +125,13 @@ func TestFileExist(t *testing.T) {
 func TestFindNotExistKeys(t *testing.T) {
 	//path := "/home/learnGoroutine/file/src.log"
 	path := "/home/learnGoroutine/file/gongshang_pc_test.log"
+	dataSource := "pc"
 	var keys []string
-	for _, v := range source["pc"] {
-		keys = append(keys, v)
+	for k := range source[dataSource] {
+		keys = append(keys, k)
 	}
 	//sort.Strings(keys)
-	output, err := FindNotExistKeys(path, keys)
+	output, err := FindNotExistKeys(path, dataSource, keys)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -143,11 +144,12 @@ func TestFindNotExistKeys(t *testing.T) {
 func BenchmarkFindNotExistKeys(b *testing.B) {
 	path := "/home/learnGoroutine/file/gongshang_pc_test.log"
 	var keys []string
-	for _, v := range source["pc"] {
-		keys = append(keys, v)
+	dataSource := "mini"
+	for k := range source[dataSource] {
+		keys = append(keys, k)
 	}
 	for i := 0; i < b.N; i++ {
-		_, err := FindNotExistKeys(path, keys)
+		_, err := FindNotExistKeys(path, dataSource, keys)
 		if err != nil {
 			b.Error(err)
 			return


### PR DESCRIPTION
1.对关键字进行严格精准匹配，防止误判
2.优化关键字匹配函数，增加对不同数据源的支持，只需修改读取的源文件和对应的数据源名称