### PR TITLE
hotfix：修复基准测试函数无法运行的问题

### DIFF
--- a/file/file_test.go
+++ b/file/file_test.go
@@ -119,7 +119,13 @@ func TestFileExist(t *testing.T) {
 	if err != nil {
 		fmt.Println(err, n)
 	}
-	defer f.Close()
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	}()
 }
 
 func TestFindNotExistKeys(t *testing.T) {
@@ -141,13 +147,32 @@ func TestFindNotExistKeys(t *testing.T) {
 	fmt.Println(output)
 }
 
+// go test -bench=. -run=none -benchmem -benchtime=3s
+// -bench=.表示运行所有的基准测试，-bench=BenchmarkFindNotExistKeys表示只允许该基准函数
+// -run=none表示不运行TestFindNotExistKeys函数，-benchtime=3s表示设置基准测试运行的时间（默认为1s）
+// -benchmem表示显示memory指标（也就是再PASS这一行多显示 B/op 和 allocs/op）
+// 15表示3s内运行的次数（b.N的数值），220301926 ns/op表示执行一次循环耗时220301926纳秒
+// B/op 表示执行一次循环分配的内存数（字节，Byte）；allocs/op表示执行一次操作分配的内存次数
+//
+// goos表示操作系统，goarch表示平台的体系架构，pkg表示运行的文件所在的包
+// BenchmarkFindNotExistKeys表示基准测试函数名
+//
+//goos: linux
+//goarch: amd64
+//pkg: GopherUtils/file
+//BenchmarkFindNotExistKeys             15         220301926 ns/op         1485740 B/op       2629 allocs/op
+//PASS
+//ok      GopherUtils/file        3.525s
 func BenchmarkFindNotExistKeys(b *testing.B) {
 	path := "/home/learnGoroutine/file/gongshang_pc_test.log"
 	var keys []string
-	dataSource := "mini"
+	dataSource := "pc"
 	for k := range source[dataSource] {
 		keys = append(keys, k)
 	}
+
+	// 重置计时器，会将运行事件归零，然后从下面的代码运行开始重新计时;过滤掉之前运行的代码所消耗的时间
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := FindNotExistKeys(path, dataSource, keys)
 		if err != nil {


### PR DESCRIPTION
1.增加对基准测试命令选项、输出内容的含义的注释 
2.优化基准测试函数代码结构，只需要更改数据源名称即读取的文件即可选择测试不同的源 
3.修复TestFileExist函数中没有对f.Close()进行错误处理的问题